### PR TITLE
the name of WAR file will be determined dynamically, according to gen…

### DIFF
--- a/src/main/java/com/airhacks/wad/boundary/WADFlow.java
+++ b/src/main/java/com/airhacks/wad/boundary/WADFlow.java
@@ -15,6 +15,7 @@ import static java.time.temporal.ChronoField.HOUR_OF_DAY;
 import static java.time.temporal.ChronoField.MINUTE_OF_HOUR;
 import static java.time.temporal.ChronoField.SECOND_OF_MINUTE;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import java.util.LongSummaryStatistics;
 import java.util.concurrent.atomic.AtomicLong;
@@ -26,7 +27,7 @@ import org.apache.maven.shared.invoker.MavenInvocationException;
  * @author airhacks.com
  */
 public class WADFlow {
-    private final List<Long> buildTimes;
+    private final Collection<Long> buildTimes;
 
     private final AtomicLong successCounter = new AtomicLong();
     private final AtomicLong buildErrorCounter = new AtomicLong();
@@ -34,7 +35,7 @@ public class WADFlow {
     private final Copier copier;
     private final Builder builder;
 
-    public WADFlow(Path dir, Path war, List<Path> deploymentTargets) throws IOException {
+    public WADFlow(Path dir, Path war, Collection<Path> deploymentTargets) throws IOException {
         this.builder = new Builder();
         this.buildTimes = new ArrayList<>();
         this.copier = new Copier(war, deploymentTargets);

--- a/src/main/java/wad/App.java
+++ b/src/main/java/wad/App.java
@@ -1,10 +1,11 @@
 
 package wad;
 
-import com.airhacks.wad.boundary.WADFlow;
-import com.airhacks.wad.control.Configurator;
 import static com.airhacks.wad.control.PreBuildChecks.pomExists;
 import static com.airhacks.wad.control.PreBuildChecks.validateDeploymentDirectories;
+
+import com.airhacks.wad.boundary.WADFlow;
+import com.airhacks.wad.control.Configurator;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
@@ -45,12 +46,6 @@ public class App {
         return Arrays.stream(args).map(App::addTrailingSlash).collect(Collectors.toList());
     }
 
-    static List<Path> addWarName(Set<Path> deploymentDirectories, String warName) {
-        return deploymentDirectories.
-                stream().
-                map(path -> path.resolve(warName)).
-                collect(Collectors.toList());
-    }
 
 
     public static void main(String[] args) throws IOException {
@@ -60,19 +55,15 @@ public class App {
             System.exit(-1);
         }
         pomExists();
-        Path currentPath = Paths.get("").toAbsolutePath();
-        Path currentDirectory = currentPath.getFileName();
-        String thinWARName = currentDirectory + ".war";
 
-        Path thinWARPath = Paths.get("target", thinWARName);
+        Path thinWARPath = Paths.get("target");
 
         Set<Path> deploymentDirs = Configurator.getConfiguredFolders(convert(args));
         validateDeploymentDirectories(deploymentDirs);
 
-        List<Path> deploymentTargets = addWarName(deploymentDirs, thinWARName);
         Path sourceCodeDir = Paths.get("./src/main/");
-        System.out.printf("WAD is watching %s, deploying %s to %s \n", sourceCodeDir, thinWARPath, deploymentTargets);
-        WADFlow wadFlow = new WADFlow(sourceCodeDir, thinWARPath, deploymentTargets);
+        System.out.printf("WAD is watching %s, deploying from dir '%s' to %s \n", sourceCodeDir, thinWARPath, deploymentDirs);
+        WADFlow wadFlow = new WADFlow(sourceCodeDir, thinWARPath, deploymentDirs);
     }
 
 }

--- a/src/test/java/com/airhacks/wad/control/CopierTest.java
+++ b/src/test/java/com/airhacks/wad/control/CopierTest.java
@@ -1,0 +1,20 @@
+package com.airhacks.wad.control;
+
+import static org.junit.Assert.assertTrue;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Optional;
+import org.junit.Test;
+
+public class CopierTest {
+
+    @Test
+    public void testFindWarInPath() {
+
+        Path path = Paths.get("src/test/resources/result");
+        Optional<Path> warInPath = new Copier(null, null).findWarInPath(path);
+        assertTrue(warInPath.isPresent());
+        assertTrue(warInPath.get().getFileName().endsWith("myApp_1.0.0-SNAPSHOT.war"));
+    }
+}

--- a/src/test/java/wad/AppTest.java
+++ b/src/test/java/wad/AppTest.java
@@ -1,9 +1,11 @@
 package wad;
 
-import java.nio.file.Path;
-import java.nio.file.Paths;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
+
+import java.io.File;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import org.junit.Test;
 
 /**
@@ -21,14 +23,13 @@ public class AppTest {
 
     @Test
     public void addTrailingSlash() {
-        String expected = "/";
+        String expected = File.separator;
 
         String actual = App.addTrailingSlash("").toString();
         assertThat(actual, is(expected));
 
-        actual = App.addTrailingSlash("/").toString();
+        actual = App.addTrailingSlash(File.separator).toString();
         assertThat(actual, is(expected));
     }
-
 
 }


### PR DESCRIPTION
In our projects, the version of a WAR will be appended to its name. Example: 

- Project Name 
  - BulkOrder
- WAR name
  - BulkOrder-3.0.0-SNAPSHOT.war

This pull request contains changes to dynamically read the name of the WAR file from target directory. Makes war name parameter #8 unnecessary